### PR TITLE
Inject credentials for getting token using IAM

### DIFF
--- a/src/auth-token-helpers/get-token-using-iam.ts
+++ b/src/auth-token-helpers/get-token-using-iam.ts
@@ -20,6 +20,11 @@ export interface IGetTokenUsingIamOpts {
   }
 
   /**
+   * Optional function for injecting credentials instead of loading credentials through the awscred library 
+   */
+  credentialFunc?: () => Promise<IAwsAuth.IAwsCredentials>
+
+  /**
    * async-retry options when token fetch fails
    */
   retryOpts?: {
@@ -150,7 +155,7 @@ export class IamTokenManager {
           return this.awsAuthClient.getTokenUsingIamLogin({
             role: this.role,
             stsRegion: this.opts.stsRegion,
-            credentials: await loadCredentials(),
+            credentials: this.opts.credentialFunc ? await this.opts.credentialFunc() : await loadCredentials(),
             iamRequestHeaders: this.opts.iamRequestHeaders
           })
         },


### PR DESCRIPTION
# Description
For getting token using the IAM method, presently, the library fetches AWS credentials using the `awscred` library. This library does not support authentication using `TokenFileWebIdentityCredentials`. So to support this capability as well as any other future authentication mechanisms, this PR includes an optional parameter `credentialFunc` which can be used to inject credentials into the library instead of supporting every form of authentication that AWS may have.

The parameter needs to be a function instead of actual credentials since the credentials can be temporary and it would be better for the library to re-fetch as needed.

## References
1. https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/TokenFileWebIdentityCredentials.html
2. https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#id1